### PR TITLE
Fixed undeclared function call by adding forward declaration

### DIFF
--- a/jeu.c
+++ b/jeu.c
@@ -45,7 +45,7 @@ int D[8][2] = { {+1,0} , {+1,+1} , {0,+1} , {-1,+1} , {-1,0} , {-1,-1} , {0,-1} 
 
 // evalue avec alpha beta la configuration 'conf' du joueur 'mode' en descendant de 'niv' niveaux
 int minmax_ab( struct config conf, int mode, int niv, int min, int max );
-
+int caseMenaceePar(int mode, int x, int y, struct config conf);
 
 /* Copie la configuration c1 dans c2  */
 void copier( struct config *c1, struct config *c2 ) 


### PR DESCRIPTION
**Problem:** call to undeclared function 'caseMenaceePar'
Starting with the ISO C99 standard, implicit function declarations are not allowed, which means the compiler requires functions to either be defined or declared before use.

**Solution:** Added a forward declaration for int MenaceePar(int mode, int x, int y, struct config conf); at the beginning of the code.

*code was generating error when compiled: *
```
#gcc -o jeu jeu.c                            
jeu.c:570:31: error: call to undeclared function 'caseMenaceePar'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  570 |                                 if (conf.mat[i][j] < 0 && caseMenaceePar(MAX, i, j, conf))
      |                                                           ^
1 error generated.```